### PR TITLE
Routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Hack Beanpot Website version 2.0
+
 This is the repo for the new hack beanpot website created for the 2019 season
 
 ## Tools
+
 - [React](https://reactjs.org/)
 - [Typescript](https://www.typescriptlang.org/docs/home.html)
 - [Sass](https://sass-lang.com/documentation/file.SASS_REFERENCE.html)
 
 ## Developing
+
 [Visual Studio Code](https://code.visualstudio.com/) is the recommended editor, and it is helpful to be familiar with command line to use `git` and `npm`.  
 To run the project, use `npm i` then `npm run start`.  
 For debugging, download the chrome extension [React Developer Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en).
 
 #### Styling
+
 In your user settings (`ctrl ,` in VSC) change the default to use 2 spaces for a tab. Use single quotes `'` instead of double quotes `"` for strings.
 
 We use Prettier for code styling. In VSC, install the prettier extension. In your user settings, add the line `"editor.formatOnSave": true` to automatically format files when you save them.
@@ -19,9 +23,11 @@ We use Prettier for code styling. In VSC, install the prettier extension. In you
 Components, props and state should be named with `CapitalizedCamelCase`. Variables are `camelCased`. File names, folder names, and CSS classes should be in `dash-separated-lowercase`.
 
 #### Structure
+
 Configuration files go in the root directory.  
-`/src` holds all the source code including assets, data, styling and components.  
-All `.scss` files should be imported into `main.scss`.  
+`/src` holds all the source code including assets, data, styling and components.
+
+**Styles:** All `.scss` files should be imported into `main.scss`. Css constants such as colors should be added to `/src/styles/constants.scss`
 
 **Shared:** Any component that will be used in multiple places belong in `/src/shared` where each component should have its own folder holding the component and associated style sheet.
 
@@ -33,22 +39,25 @@ All `.scss` files should be imported into `main.scss`.
 
 **src:** Each page should have its own folder housing all its components. If there are multiple components and style sheets within a page, they should be sorted in `/components` and `styles` subfolders.
 
-Css constants such as colors should be added to `/src/styles/constants.scss`
+**config:** When adding a new folder, keep imports clean by adding the path to `tsconfig.json` in the paths section. Likewise, use the @path statements in your imports.
 
 ## Contributing to the Repo
-When developing locally, always develop on your own branch that is rebased off of `develop`.  
-**To switch to a new branch:** While on `develop`, run `git pull` to get the latest version. `git checkout -b <branch-name>` to create and switch to a new branch (replacing `<branch-name>` with a relevant name).  
 
-When your feature is done, make sure your branch is up to date, then push your branch to the remote repo.  
+When developing locally, always develop on your own branch that is rebased off of `develop`.  
+**To switch to a new branch:** While on `develop`, run `git pull` to get the latest version. `git checkout -b <branch-name>` to create and switch to a new branch (replacing `<branch-name>` with a relevant name).
+
+When your feature is done, make sure your branch is up to date, then push your branch to the remote repo.
+
 > `git checkout develop`  
 > `git pull`  
 > `git checkout <your-branch>`  
 > `git rebase origin/develop`  
 > fix and commit any conflicts  
-> `git push origin <your-branch>`  
+> `git push origin <your-branch>`
 
-To merge your changes into `develop`, open a pull request and add reviewers and fill in the PR template. You will need 3 reviewers to approve your PR before merging.
+To merge your changes into `develop`, open a pull request and add reviewers and fill in the PR template. You will need 3 reviewers to approve your PR before merging. In your PR, do include screenshots or a gif of your feature when relevant.
 **When merging, use the squash and merge option.**
 
 ## Deployment
+
 The production version of this site is on the `master` branch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/history": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.6.2.tgz",
+      "integrity": "sha512-eVAb52MJ4lfPLiO9VvTgv8KaZDEIqCwhv+lXOMLlt4C1YHTShgmMULEg0RrCbnqfYd6QKfHsMp0MiX0vWISpSw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.0.tgz",
@@ -27,6 +33,27 @@
       "requires": {
         "@types/node": "*",
         "@types/react": "*"
+      }
+    },
+    "@types/react-router": {
+      "version": "4.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-4.0.26.tgz",
+      "integrity": "sha512-BBL/Dk/sXAlC0Ee4zJrgYp8AsM5ubITRz8kX2a+4BBkDh9E5YE+4ZqzrS6L+ec6cXb4yRHL983fEN5AsobOIHg==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-4.2.7.tgz",
+      "integrity": "sha512-6sIP3dIj6xquvcAuYDaxpbeLjr9954OuhCXnniMhnDgykAw2tVji9b0jKHofPJGUoHEMBsWzO83tjnk7vfzozA==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "css-loader": "^0.28.4",
     "html-webpack-plugin": "^3.2.0",
     "prettier": "1.13.4",
-    "react-router-dom": "^4.2.2",
+    "@types/react-router-dom": "^4.2.2",
     "sass-loader": "^6.0.6",
     "source-map-loader": "^0.2.3",
     "style-loader": "^0.18.2",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,17 +1,15 @@
 import * as React from 'react';
-import 'styles/main.scss';
+import '@styles/main.scss';
+import Stories from '@stories/stories';
+import { Switch, Route } from 'react-router-dom';
 
 class App extends React.Component {
   public render() {
     return (
-      <div className="app">
-        <header className="app-header">
-          <h1 className="app-title">This our website</h1>
-        </header>
-        <p className="app-intro">
-          Welcome to hack beanpot 2019
-        </p>
-      </div>
+      <Switch>
+        {/* For main page routing, follow the pattern for the stories path. */}
+        <Route exact path={'/stories'} component={Stories} />
+      </Switch>
     );
   }
 }

--- a/src/stories/stories.tsx
+++ b/src/stories/stories.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+class Stories extends React.Component {
+  render() {
+    return (
+      <h1>Stories page placeholder</h1>
+    );
+  }
+}
+
+export default Stories;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,14 @@
     "preserveConstEnums": true,
     "removeComments": true,
     "sourceMap": true,
-    "target": "es5"
+    "target": "es5",
+    "typeRoots": ["./node_modules/@types"],
+    "baseUrl": "./src",
+    "paths": {
+      "@app/*": ["./*"],
+      "@styles/*": ["./styles/*"],
+      "@stories/*": ["./stories/*"]
+    }
   },
-  "include": [
-    "./src/**/**/*"
-  ]
+  "include": ["./src/**/**/*"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path'),
   webpack = require('webpack'),
   HtmlWebpackPlugin = require('html-webpack-plugin');
+const { TsConfigPathsPlugin } = require('awesome-typescript-loader');
 
 module.exports = {
   entry: {
@@ -9,30 +10,42 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'js/[name].bundle.js'
+    filename: 'js/[name].bundle.js',
+    publicPath: '/'
   },
   devtool: 'source-map',
+  devServer: {
+    historyApiFallback: true
+  },
   resolve: {
     extensions: ['.js', '.jsx', '.json', '.ts', '.tsx'],
-    alias: {
-      styles: path.resolve('./src/styles')
-    }
+    modules: [path.resolve('./node_modules')],
+    plugins: [new TsConfigPathsPlugin()]
   },
   module: {
     rules: [
       {
         test: /\.(ts|tsx)$/,
-        loader: 'ts-loader'
+        use: [
+          {
+            loader: 'awesome-typescript-loader'
+          }
+        ],
+        exclude: /node_modules/
       },
       {
         test: /\.scss$/,
-        loader: "style-loader!css-loader!sass-loader"
+        loader: 'style-loader!css-loader!sass-loader'
       },
-      { enforce: "pre", test: /\.js$/, loader: "source-map-loader" }      
+      { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' }
     ]
+  },
+  watchOptions: {
+    poll: 1000,
+    ignored: /node_modules/
   },
   plugins: [
     new HtmlWebpackPlugin({ template: path.resolve(__dirname, 'index.html') }),
     new webpack.HotModuleReplacementPlugin()
   ]
-}
+};


### PR DESCRIPTION
we got some routes!!

Fixed up a bunch of config issues to have sexier imports and set up routing using [react-router-dom](https://reacttraining.com/react-router/web/guides/philosophy).

Currently, `/stories` will lead to a placeholder page, and all the routing to the main pages will be done in `src/app.tsx` following the pattern of the stories route. And the documentation linked above is really helpful too.

As a side note, I used `exact` in my route since stories will likely just be that one path, but something like projects wouldn't want `exact` since there will be multiple subpaths, and the projects component would have its own routing to get to each year (assuming the page isn't just a full scroll, I can't remember what we decided)

Lastly, note the addition to the README about configuring import paths!