### PR TITLE
Try to fix merge conflict issue with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,8 @@ jobs:
               git stash
               git checkout gh-pages
               find . -mindepth 1 -maxdepth 1  ! -path './.git' ! -path './.git/*' ! -name '.gitignore' ! -path './.circleci' ! -path './.circleci/*' ! -name 'CNAME' -exec rm -rf {} +
-              git add -u
-              git stash pop
+              git checkout stash -- .
+              git stash drop
               cp -r public/ .
               rm -rf public
               git add -A


### PR DESCRIPTION
The issue CircleCI encountered last PR is that when it tried to `stash pop` the master build into gh-pages, there were conflicts between the two builds and the pop was aborted.

This change makes it so that CircleCI forcibly overwrites the contents of gh-pages with the contents of its stash while popping. I think this change will fix our bug from before. It will also cause CircleCI to commit a bunch of extraneous files to gh-pages but we can clean them up in a future PR as long as the build works.