### PR TITLE
If this doesn't work I will eat my own socks at the next meeting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,17 @@ jobs:
 
 
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "b0:5a:c3:32:6c:a7:a2:9c:e9:03:d3:ad:b3:8e:80:a6"
+
       - checkout
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
 
       - run: 
           name: install dependencies


### PR DESCRIPTION
Tells circleci to use the read/write deploy key instead of the read-only deploy key. Probably.