### PR TITLE
Fix theme-color to be on brand, temp fix for favicons, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ First and foremost, make sure you have [Node](https://nodejs.org) installed.
 `git clone https://github.com/HackBeanpot/www-2019` Clone into this repository.
 `cd www-2019` CD into the new local repo.
 `npm install` Install dependencies.
+`npm install --global gatsby-cli` Install Gatsby
 `gatsby develop` Launch a hot-reloading dev environment to see the site running on your local!
 
 ## Branch Structure

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -2,19 +2,32 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 
-import StaticFooter from "../components/static-footer";
+import StaticFooter from '../components/static-footer';
 import Nav from 'components/nav';
 import 'styles/global-style.scss';
+import favicon from '../pages/favicon.png';
 
 // Shows the header and footer on every page
 const Layout = ({ children }) => (
   <div>
     <Helmet
-      title={'HackBeanpot'}
+      title="HackBeanpot 2019"
       meta={[
-        { name: 'description', content: 'A Boston area hackathon' },
-        { name: 'keywords', content: 'Hack Beanpot' }
+        {
+          name: 'description',
+          content:
+            'An independently-run Boston hackathon for curious students, hackers, makers, and beginners.'
+        },
+        {
+          name: 'keywords',
+          content: 'hackathon, boston, students, hackers, makers, beginners'
+        },
+        {
+          name: 'theme-color',
+          content: '#A4DBE8'
+        }
       ]}
+      link={[{ rel: 'shortcut icon', type: 'image/png', href: `${favicon}` }]}
     />
     <Nav />
     <div>{children()}</div>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -39,7 +39,7 @@ const App = () => {
           },
           {
             name: 'theme-color',
-            content: '#db5945'
+            content: '#A4DBE8'
           }
         ]}
         link={[{ rel: 'shortcut icon', type: 'image/png', href: `${favicon}` }]}


### PR DESCRIPTION
Hey guys! I kinda had some spare time and was curious so I was digging around the site and made some super small fixes. I know they're not anything important but I hope they help you guys out 😄. Here's the short of it:

- SMALL fix but I was following the README instructions to build the site for the first time and did not know that I had to install Gatsby separately. So... added that for future bumblers 😇 
- Updated the `<meta theme-color>` property that somehow got set as a color that wasn't in our brand identity? Changed it to HBP baby blue and it looks super cute now, I hope that's alright.
- Also, as I was looking into the theme-color, I think I figured out why the favicon doesn't show up on all pages. The index.jsx in `/src/pages/` uses a different (hardcoded) `<head>` than the rest of the pages, which pull from `/src/layouts/`. I think that would mean reworking the main homepage to also use the main *layout* index.jsx, but in the meanwhile I just changed the layout `<head>` to be the same as the homepage `<head>` (and also added a relative `import` for the favicon... idk if that's ok or not). I also just realized you guys probably know all of this already, but let me know if the fix helps in the short term (otherwise I can remove it from the PR)!

Let me know how everything looks! Hope I'm not stepping on y'all toes or anything ☹️ 