### PR TITLE
Close registration

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -48,18 +48,9 @@ const App = () => {
             <h2 className="header__event-date">February 7-9, 2020</h2>
             <p className="header__description">
               An independently-run Boston hackathon for curious students,
-              hackers, makers, and beginners. Applications for HackBeanpot 2020
-              are open now!
+              hackers, makers, and beginners.
             </p>
-            <a
-              className="header__cta"
-              href="https://apply.hackbeanpot.com/login"
-              role="button"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Apply here
-            </a>
+            <p className="header__description"><strong>Applications for our 2020 hackathon are currently closed.</strong></p>
           </div>
           <div className="header__skyline">
             <Skyline />


### PR DESCRIPTION
This PR replaces the "Apply now" CTA with text saying the hackathon is closed.

Screenshot of the new site:
![Screen Shot 2020-01-16 at 9 22 09 PM](https://user-images.githubusercontent.com/8844961/72579226-7fea2780-38a6-11ea-8fa1-c07be8c7136a.png)
