### PR TITLE
Remove registration CTA and add 2020 sponsor logos

### DIFF
--- a/src/components/sponsors-2020.jsx
+++ b/src/components/sponsors-2020.jsx
@@ -1,7 +1,186 @@
 import React from 'react';
 
 const Sponsors2020 = () => (
-  <div>
+  <div class="container">
+    {/* Catalant */}
+    <div className="row">
+      <div className="col-3"/>
+      <a
+        href="https://gocatalant.com/"
+        className="col-md-6 d-flex align-items-center"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          src="https://tools.hackbeanpot.com/assets/logos/2020-sponsors/catalant_1000px.png"
+          alt="Catalant logo"
+        />
+      </a>
+      <div className="col-3"/>
+    </div>
+
+    <br/>
+
+    {/* Kyruus */}
+    <div className="row">
+      <div className="col-4"/>
+      <a
+        href="https://www.kyruus.com/"
+        className="col-md-4 d-flex align-items-center"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          src="https://tools.hackbeanpot.com/assets/logos/2020-sponsors/kyruus_3177px.png"
+          alt="Kyruus logo"
+        />
+      </a>
+      <div className="col-4"/>
+    </div>
+
+    {/* PowerAdvocate and Drift */}
+    <div className="row">
+      <div className="col-1"/>
+      <a
+        href="https://w3.poweradvocate.com/"
+        className="col-md-4 d-flex align-items-center"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          src="https://tools.hackbeanpot.com/assets/logos/2020-sponsors/poweradvocate_1436px.png"
+          alt="PowerAdvocate logo"
+        />
+      </a>
+      <div className="col-2"/>
+      <a
+        href="https://www.drift.com/"
+        className="col-md-4 d-flex align-items-center"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          src="https://tools.hackbeanpot.com/assets/logos/2020-sponsors/drift_2500px.png"
+          alt="Drift logo"
+        />
+      </a>
+      <div className="col-1"/>
+    </div>
+
+    {/* Intuit and Khoury */}
+    <div className="row">
+      <div className="col-1"/>
+      <a
+        href="https://www.intuit.com/"
+        className="col-md-5 d-flex align-items-center"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          src="https://tools.hackbeanpot.com/assets/logos/2020-sponsors/intuit_1016px.png"
+          alt="Intuit logo"
+        />
+      </a>
+      <a
+        href="https://www.khoury.northeastern.edu/"
+        className="col-md-5 d-flex align-items-center"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          src="https://tools.hackbeanpot.com/assets/logos/2020-sponsors/khoury_1200px.png"
+          alt="Khoury logo"
+        />
+      </a>
+      <div className="col-1"/>
+    </div>
+
+    {/* Bookbub, DataDog, Simplisafe */}
+    <div className="row">
+      <a
+        href="https://www.bookbub.com/"
+        className="col-md-4 d-flex align-items-center"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          src="https://tools.hackbeanpot.com/assets/logos/2020-sponsors/bookbub_1652px.png"
+          alt="BookBub logo"
+        />
+      </a>
+      <a
+        href="https://www.datadoghq.com/"
+        className="col-md-4 d-flex align-items-center"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          src="https://tools.hackbeanpot.com/assets/logos/2020-sponsors/datadog_931px.png"
+          alt="DataDog logo"
+        />
+      </a>
+      <a
+        href="https://simplisafe.com/"
+        className="col-md-4 d-flex align-items-center"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          src="https://tools.hackbeanpot.com/assets/logos/2020-sponsors/simplisafe_1024px.png"
+          alt="SimpliSafe logo"
+        />
+      </a>
+    </div>
+
+    <br/>
+
+    {/* PluralSign and Upstatement */}
+    <div className="row">
+      <div className="col-2"/>
+      <a
+        href="https://www.pluralsight.com/"
+        className="col-md-4 d-flex align-items-center"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          src="https://tools.hackbeanpot.com/assets/logos/2020-sponsors/pluralsight_975.png"
+          alt="Pluralsight logo"
+        />
+      </a>
+      <a
+        href="https://www.upstatement.com/"
+        className="col-md-4 d-flex align-items-center"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          className="catalant-logo"
+          src="https://tools.hackbeanpot.com/assets/logos/2020-sponsors/upstatement_3135px.png"
+          alt="Upstatement logo"
+        />
+      </a>
+      <div className="col-2"/>
+    </div>
+
+    <br/>
+
+    {/* Yelp */}
+    <div className="row">
+      <div className="col-5"/>
+      <a
+        href="https://www.yelp.com/"
+        className="col-md-2 d-flex align-items-center"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          src="https://tools.hackbeanpot.com/assets/logos/2020-sponsors/yelp_1280px.png"
+          alt="Yelp logo"
+        />
+      </a>
+      <div className="col-5"/>
+    </div>
   </div>
 );
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -48,18 +48,9 @@ const App = () => {
             <h2 className="header__event-date">February 7-9, 2020</h2>
             <p className="header__description">
               An independently-run Boston hackathon for curious students,
-              hackers, makers, and beginners. Applications for HackBeanpot 2020
-              are open now!
+              hackers, makers, and beginners.
             </p>
-            <a
-              className="header__cta"
-              href="https://apply.hackbeanpot.com/login"
-              role="button"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Apply here
-            </a>
+            <p className="header__description"><strong>Applications for our 2020 hackathon are currently closed.</strong></p>
           </div>
           <div className="header__skyline">
             <Skyline />

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -5,6 +5,7 @@ import FAQItems from 'components/faqItems/faq-items';
 import AboutItem from 'components/aboutItem/about-item';
 import DynamicLink from 'components/dynamic-link';
 import AboutContent from 'data/about-content.json';
+import Sponsors2020 from 'components/sponsors-2020'
 
 import Skyline from 'images/svg/skyline.jsx';
 import LogoAnimation from 'images/logo-sprout.gif';
@@ -129,28 +130,7 @@ const App = () => {
           </span>
           <div className="container">
             <h2 className="home-sponsors__title">Our Sponsors</h2>
-            <div className="home-sponsors__content">
-              <p>
-                Check back closer to the event for a full list of our
-                HackBeanpot 2020 sponsors.
-              </p>
-              <p>
-                If your company is interested in joining the HackBeanpot
-                community and becoming a sponsor, reach out to us!
-              </p>
-            </div>
-            <div className="home-sponsors__cta-group">
-              <a
-                href="mailto:sponsorship@hackbeanpot.com"
-                role="button"
-                className="home-sponsors__cta"
-              >
-                Email us
-              </a>
-              <DynamicLink className="home-sponsors__cta-link" to="/sponsors">
-                Or visit our Sponsors Page
-              </DynamicLink>
-            </div>
+            <Sponsors2020 />
           </div>
         </section>
       </div>

--- a/src/styles/_normalize.scss
+++ b/src/styles/_normalize.scss
@@ -146,6 +146,7 @@ sup {
  */
 
 img {
+  width: 100%;
   border-style: none;
 }
 

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -215,15 +215,6 @@
   @include bottom-margin;
 }
 
-.home-sponsors__content {
-  width: 100%;
-  margin-bottom: 40px;
-
-  @media (min-width: $md) {
-    width: 45%;
-  }
-}
-
 .home-sponsors__cta-group {
   display: flex;
   align-items: center;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -2,7 +2,7 @@
 
 // Vendor
 @import './normalize.scss';
-@import 'node_modules/bootstrap/scss/bootstrap.scss';
+@import url('https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css');
 @import './flickity.scss';
 
 // Global helpers


### PR DESCRIPTION
This PR replaces the "Apply now" button with text saying that registration has closed.

It also adds the 2020 sponsor logos.